### PR TITLE
ci(gh-actions): add Mac OS 26 runners on test workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,11 +42,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-latest # ubuntu-24.04
           - ubuntu-24.04-arm
-          - windows-latest
+          - windows-latest # windows-2025
           - windows-11-arm
-          - macos-latest
+          - macos-26
+          - macos-26-intel
+          - macos-latest # macos-15
           - macos-15-intel
     permissions:
       id-token: write # to use OIDC


### PR DESCRIPTION
https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/